### PR TITLE
Fixed path when replacing artifactory.war

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN \
   rm artifactory.zip
 
 # Add hook to install custom artifactory.war (i.e. Artifactory Pro) to replace the default OSS installation.
-ONBUILD ADD ./artifactory.war webapps/
+ONBUILD ADD ./artifactory.war $CATALINA_HOME/webapps/
 
 # Expose tomcat runtime options through the RUNTIME_OPTS environment variable.
 #   Example to set the JVM's max heap size to 256MB use the flag


### PR DESCRIPTION
Without using $CATALINA_HOME (or a hardcoded absolute path) the new
artifactory.war is placed in the wrong directory:

```
find / -name artifactory.war
/usr/local/tomcat/webapps/artifactory.war
/webapps/artifactory.war
```