### PR TITLE
Don't enforce ONBUILD add of *.war

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,6 @@ RUN \
   unzip -j artifactory.zip "artifactory-*/webapps/artifactory.war" -d webapps && \
   rm artifactory.zip
 
-# Add hook to install custom artifactory.war (i.e. Artifactory Pro) to replace the default OSS installation.
-ONBUILD ADD ./artifactory.war webapps/
-
 # Expose tomcat runtime options through the RUNTIME_OPTS environment variable.
 #   Example to set the JVM's max heap size to 256MB use the flag
 #   '-e RUNTIME_OPTS="-Xmx256m"' when starting a container.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ If you are using Artifactory Pro, the artifactory war archive has to be replaced
 
     # Dockerfile for Artifactory Pro
     FROM mattgruter/artifactory
+    ADD ./artifactory.war /tomcat/webapps
 
 Now build your child docker image:
 
     docker build -t yourname/myartifactory
 
-The `ONBUILD` trigger makes sure that your `artifactory.war` is picked up and applied to the image upon build.
+The ADD ensures your `artifactory.war` is picked up and applied to the image upon build.
 
     docker run -P yourname/myartifactory

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you are using Artifactory Pro, the artifactory war archive has to be replaced
 
     # Dockerfile for Artifactory Pro
     FROM mattgruter/artifactory
-    ADD ./artifactory.war /tomcat/webapps
+    ADD ./artifactory.war /usr/local/tomcat/webapps
 
 Now build your child docker image:
 


### PR DESCRIPTION
.. rather document the ADD in the README which is just as easy and allows for it to be downloaded from an internal server,  etc.

Note that the previous ONBUILD didn't work anyway, as it would add the 'war'  to
`/artifactory/webapps` rather than /usr/local/tomcat/webapps

I actually use that bug as a workaround to use  `FROM mattgruter/artifactory` in my [artifactory-with-mysql](https://registry.hub.docker.com/u/stain/artifactory-with-mysql/) image to customize mysql support. 

