### PR TITLE
Fix link to artifactory versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:7-jre7
 
 MAINTAINER Matthias Grüter <matthias@grueter.name>
 
-# To update, check https://bintray.com/jfrog/artifactory/artifactory/view
+# To update the version, check http://subversion.jfrog.org/artifactory/public/tags/
 ENV ARTIFACTORY_VERSION 3.9.2
 ENV ARTIFACTORY_SHA1 245aeb7b2d77830462067d5a19c3bd32ae014ddf
 


### PR DESCRIPTION
I'm not sure if there's a better URL than the view over which versions exist in the artifactory repo, but since https://bintray.com/jfrog/artifactory/artifactory/view gives 404 I wanted to suggest this change.
